### PR TITLE
Add ability to create Writer with config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,25 @@ BenchmarkBZip2Read/1000000B-8                200          76655666 ns/op
 BenchmarkBZip2Read/10000000B-8                20         745520450 ns/op
 BenchmarkBZip2Read/100000000B-8                2        8047164946 ns/op
 ```
+
+## Usage
+
+### Reader
+
+```go
+// If pbzip2 is not present on the system, stdlib bzip2.Reader is used instead.
+func NewReader(r io.Reader) (io.ReadCloser, error) { ... }
+```
+
+### Writer
+
+```go
+// NewWriter will use the default Level of 9
+func NewWriter(w io.Writer) (io.WriteCloser, error) { ... }
+
+type WriterConfig struct {
+    Level int
+}
+
+func NewWriterConfig(w io.Writer, conf *WriterConfig) (io.WriteCloser, error) { ... }
+```

--- a/pbzip2.go
+++ b/pbzip2.go
@@ -1,18 +1,23 @@
-// pbzip2 is a wrapper around the pbzip2 command. If it's present on the system,
-// this library will use it for higher performance when decompressing bzip2
-// data.
+// Package pbzip2 is a wrapper around the pbzip2 command. If it's present on
+// the system, this library will use it for higher performance when
+// decompressing bzip2 data.
 package pbzip2
 
 import (
-	"compress/bzip2"
-	"io"
-	"os"
 	"os/exec"
-
-	"github.com/pkg/errors"
 )
 
-const Command = "pbzip2"
+const (
+	// Command is the pbzip2 command
+	Command = "pbzip2"
+
+	// BestSpeed represents the smallest block size (100k)
+	BestSpeed = 1
+	// BestCompression represents the largest block size (900k)
+	BestCompression = 9
+	// DefaultCompression represents the default block size (900k)
+	DefaultCompression = 9
+)
 
 func hasPBZip2() bool {
 	cmd := exec.Command(Command, "--version")
@@ -20,77 +25,4 @@ func hasPBZip2() bool {
 		return false
 	}
 	return true
-}
-
-// NewReader creates a new pbzip2 reader. This will print a warning if pbzip2 is
-// not present on the system and return a stdlib bzip2.Reader instead.
-func NewReader(r io.Reader) (io.ReadCloser, error) {
-	if !hasPBZip2() {
-		warn()
-		return bzip2Closer{bzip2.NewReader(r)}, nil
-	}
-
-	cmd := exec.Command(Command, "-d")
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = r
-
-	out, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, err
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-	return pbzip2Reader{
-		ReadCloser: out,
-		cmd:        cmd,
-	}, nil
-}
-
-type pbzip2Reader struct {
-	io.ReadCloser
-	cmd *exec.Cmd
-}
-
-func (p pbzip2Reader) Close() error {
-	if err := p.ReadCloser.Close(); err != nil {
-		return err
-	}
-	return p.cmd.Wait()
-}
-
-// NewWriter creates a new pbzip2 writer. This will return an error if pbzip2 is
-// not present on the system.
-func NewWriter(w io.Writer) (io.WriteCloser, error) {
-	if !hasPBZip2() {
-		return nil, errors.Errorf("missing pbzip2 from system")
-	}
-
-	cmd := exec.Command(Command, "-z")
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = w
-
-	in, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, err
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-	return pbzip2Writer{
-		WriteCloser: in,
-		cmd:         cmd,
-	}, nil
-}
-
-type pbzip2Writer struct {
-	io.WriteCloser
-	cmd *exec.Cmd
-}
-
-func (p pbzip2Writer) Close() error {
-	if err := p.WriteCloser.Close(); err != nil {
-		return err
-	}
-	return p.cmd.Wait()
 }

--- a/pbzip2_test.go
+++ b/pbzip2_test.go
@@ -34,64 +34,6 @@ func testStringN(t testing.TB, targetLen int64) string {
 	return out
 }
 
-func TestWriter(t *testing.T) {
-	var buf bytes.Buffer
-	writer, err := NewWriter(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	in := testString(t)
-	if _, err := writer.Write([]byte(in)); err != nil {
-		t.Fatal(err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	reader := bzip2.NewReader(&buf)
-	body, err := ioutil.ReadAll(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	out := string(body)
-	if out != in {
-		t.Errorf("%q != %q", out, in)
-	}
-}
-
-func TestReader(t *testing.T) {
-	var buf bytes.Buffer
-	writer, err := NewWriter(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	in := testString(t)
-	if _, err := writer.Write([]byte(in)); err != nil {
-		t.Fatal(err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	reader, err := NewReader(&buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, err := ioutil.ReadAll(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	out := string(body)
-	if out != in {
-		t.Errorf("%q != %q", out, in)
-	}
-	if err := reader.Close(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 var benchSizes = []int64{1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000}
 
 func BenchmarkPBZip2Read(b *testing.B) {

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,45 @@
+package pbzip2
+
+import (
+	"compress/bzip2"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// NewReader creates a new pbzip2 reader. This will print a warning if pbzip2 is
+// not present on the system and return a stdlib bzip2.Reader instead.
+func NewReader(r io.Reader) (io.ReadCloser, error) {
+	if !hasPBZip2() {
+		warn()
+		return bzip2Closer{bzip2.NewReader(r)}, nil
+	}
+
+	cmd := exec.Command(Command, "-d")
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = r
+
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return pbzip2Reader{
+		ReadCloser: out,
+		cmd:        cmd,
+	}, nil
+}
+
+type pbzip2Reader struct {
+	io.ReadCloser
+	cmd *exec.Cmd
+}
+
+func (p pbzip2Reader) Close() error {
+	if err := p.ReadCloser.Close(); err != nil {
+		return err
+	}
+	return p.cmd.Wait()
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -1,0 +1,39 @@
+package pbzip2
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestReader(t *testing.T) {
+	var buf bytes.Buffer
+	writer, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := testString(t)
+	if _, err := writer.Write([]byte(in)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewReader(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := string(body)
+	if out != in {
+		t.Errorf("%q != %q", out, in)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,91 @@
+package pbzip2
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+// WriterConfig stores configuration options for a pbzip2 writer
+type WriterConfig struct {
+	Level int
+}
+
+type pbzip2Writer struct {
+	io.WriteCloser
+	cmd *exec.Cmd
+}
+
+// NewWriter creates a new pbzip2 writer. This will return an error if pbzip2 is
+// not present on the system.
+func NewWriter(w io.Writer) (io.WriteCloser, error) {
+	defaultConf := newDefaultWriterConfig()
+
+	return newPbzip2Writer(w, defaultConf)
+}
+
+// NewWriterConfig creates a new pbzip2 writer with configuration options.
+// This will return an error if pbzip2 is not present on the system.
+func NewWriterConfig(w io.Writer, conf *WriterConfig) (io.WriteCloser, error) {
+	if conf == nil {
+		return NewWriter(w)
+	}
+
+	return newPbzip2Writer(w, conf)
+}
+
+func newPbzip2Writer(w io.Writer, conf *WriterConfig) (io.WriteCloser, error) {
+	if !hasPBZip2() {
+		return nil, errors.New("missing pbzip2 from system")
+	}
+
+	err := conf.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	lvl := fmt.Sprintf("-%d", conf.Level)
+	cmd := exec.Command(Command, "-z", lvl)
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = w
+
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	return pbzip2Writer{
+		WriteCloser: in,
+		cmd:         cmd,
+	}, nil
+}
+
+func newDefaultWriterConfig() *WriterConfig {
+	return &WriterConfig{
+		Level: DefaultCompression,
+	}
+}
+
+func (wc *WriterConfig) validate() error {
+	if wc.Level == 0 {
+		wc.Level = DefaultCompression
+	}
+	if wc.Level < BestSpeed || wc.Level > BestCompression {
+		return fmt.Errorf("invalid compression level: %d", wc.Level)
+	}
+
+	return nil
+}
+
+func (p pbzip2Writer) Close() error {
+	if err := p.WriteCloser.Close(); err != nil {
+		return err
+	}
+	return p.cmd.Wait()
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,123 @@
+package pbzip2
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"io/ioutil"
+	"testing"
+)
+
+func TestWriter(t *testing.T) {
+	var buf bytes.Buffer
+	writer, err := NewWriter(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := testString(t)
+	if _, err := writer.Write([]byte(in)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := bzip2.NewReader(&buf)
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := string(body)
+	if out != in {
+		t.Errorf("%q != %q", out, in)
+	}
+}
+
+func TestWriterConfig(t *testing.T) {
+	var buf bytes.Buffer
+	conf := &WriterConfig{Level: 6}
+	writer, err := NewWriterConfig(&buf, conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := testString(t)
+	if _, err := writer.Write([]byte(in)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := bzip2.NewReader(&buf)
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := string(body)
+	if out != in {
+		t.Errorf("%q != %q", out, in)
+	}
+}
+
+func TestWriterConfigNil(t *testing.T) {
+	var buf bytes.Buffer
+	writer, err := NewWriterConfig(&buf, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := testString(t)
+	if _, err := writer.Write([]byte(in)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := bzip2.NewReader(&buf)
+	body, err := ioutil.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out := string(body)
+	if out != in {
+		t.Errorf("%q != %q", out, in)
+	}
+}
+
+func TestNewDefaultWriterConfig(t *testing.T) {
+	defaultConf := newDefaultWriterConfig()
+
+	if defaultConf.Level != DefaultCompression {
+		t.Errorf("expected default config level %d, got: %d",
+			DefaultCompression, defaultConf.Level)
+	}
+}
+
+func TestWriterConfigValidate(t *testing.T) {
+	// Level of 0 gets set to default
+	conf1 := &WriterConfig{Level: 0}
+	err := conf1.validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf1.Level != DefaultCompression {
+		t.Errorf("expected default config level %d, got: %d",
+			DefaultCompression, conf1.Level)
+	}
+
+	// Level out of lower range
+	conf2 := &WriterConfig{Level: -1}
+	err = conf2.validate()
+	if err == nil {
+		t.Error("exptected error with writer config Level of -1")
+	}
+
+	// Level out of upper range
+	conf3 := &WriterConfig{Level: 10}
+	err = conf3.validate()
+	if err == nil {
+		t.Error("exptected error with writer config Level of 10")
+	}
+}


### PR DESCRIPTION
This adds the ability to create a Writer with a config. The only supported config right now is `Level` for setting the block size.

I've also split up the `reader` and `writer` code as well as the tests.